### PR TITLE
Um support

### DIFF
--- a/ermine-breeder
+++ b/ermine-breeder
@@ -448,6 +448,7 @@ if [ "$ARCH" = all ]; then
   $0 --arch x86_64 $CONFOPT
   $0 --arch arm $CONFOPT
   $0 --arch arm64 $CONFOPT
+  $0 --arch um $CONFOPT
   exit $?
 fi
 

--- a/ermine-breeder
+++ b/ermine-breeder
@@ -26,6 +26,7 @@ get_latest_kernel_url() {
 LINUX_URL=`get_latest_kernel_url`
 BUSYBOX_URL=http://busybox.net/downloads/busybox-1.26.2.tar.bz2
 LIBCAP_URL=https://github.com/mhiramat/libcap/archive/capsh-exec-v1.zip
+UM_LINUX_URL=https://github.com/mhiramat/linux/archive/um-quiet.zip
 
 # Cross tools
 GCC_arm64_URL=http://releases.linaro.org/components/toolchain/binaries/latest-6/aarch64-linux-gnu/gcc-linaro-6.2.1-2016.11-x86_64_aarch64-linux-gnu.tar.xz
@@ -494,6 +495,11 @@ if [ $HOSTARCH != $ARCH ]; then
   GCCDIR=$WORKDIR/gcc-$ARCH
   setup_source $GCC_URL $GCCDIR
   export PATH="$PATH:"`ls -d $GCCDIR/*/bin`
+fi
+#TODO: After the um-quiet patchset merged to stable, this should be removed
+if [ "$ARCH" = "um" ]; then
+  LINUX_URL=$UM_LINUX_URL
+  echo "Note: LINUX_URL is replaced by $UM_LINUX_URL, since um-quiet series is not merged yet."
 fi
 setup_source $LINUX_URL $LINUXDIR
 setup_source $BUSYBOX_URL $BUSYBOXDIR

--- a/ermine-breeder
+++ b/ermine-breeder
@@ -168,6 +168,7 @@ configure_kernel() { # outdir
     # config user mode linux configs
     kconfigs_y HOSTFS UML_NET UML_NET_TUNTAP PTY_CHAN NULL_CHAN TTY_CHAN \
 	    BINFMT_MISC BLOCK BLK_DEV BLK_DEV_INITRD
+    kconfigs_n BLK_DEV_UBD
   else
     # config kvm configs (for older arm/arm64 kernels)
     kconfigs_y VIRTUALIZATION HYPERVISOR_GUEST PARAVIRT KVM_GUEST \

--- a/ermine-breeder
+++ b/ermine-breeder
@@ -207,6 +207,7 @@ build_kernel() { # workdir rebuild
     um)
     make vmlinux -j $JOBS O=$OUTDIR
     cp -f $OUTDIR/vmlinux $VMLINUZ
+    strip $VMLINUZ
     ;;
   esac
   )

--- a/ermine-breeder
+++ b/ermine-breeder
@@ -154,6 +154,8 @@ configure_kernel() { # outdir
   make defconfig O=$1
   user_configure_kernel $1
   kconfig_string DEFAULT_HOSTNAME "ermine"
+  # fundamental features
+  kconfigs_y NET NET_CORE NETDEVICES TTY INET IP_PNP IP_PNP_DHCP BINFMT_ELF
   # config minc related configs
   kconfigs_y OVERLAY_FS NAMESPACES UTS_NS IPC_NS USER_NS PID_NS NET_NS \
     CGROUPS EVENTFD CGROUP_DEVICE CPUSETS CGROUP_CPUACCT \
@@ -161,14 +163,22 @@ configure_kernel() { # outdir
     CGROUP_PERF CGROUP_SCHED CGROUP_HUGETLB FAIR_GROUP_SCHED \
     CGROUP_PIDS CGROUP_FREEZER CFS_BANDWIDTH RT_GROUP_SCHED \
     BLK_CGROUP
-  # config kvm configs (for older arm/arm64 kernels)
-  kconfigs_y NET NET_CORE NETDEVICES BLOCK BLK_DEV TTY PCI PCI_MSI \
-    SERIAL_8250 SERIAL_8250_CONSOLE INET IP_PNP IP_PNP_DHCP BINFMT_ELF \
-    VIRTUALIZATION HYPERVISOR_GUEST PARAVIRT KVM_GUEST VIRTIO \
-    VIRTIO_PCI VIRTIO_BLK VIRTIO_CONSOLE VIRTIO_NET VIRTIO_INPUT \
-    NETWORK_FILESYSTEMS NET_9P NET_9P_VIRTIO 9P_FS 9P_FS_POSIX_ACL
+
+  if [ $ARCH = um ]; then
+    # config user mode linux configs
+    kconfigs_y HOSTFS UML_NET UML_NET_TUNTAP PTY_CHAN NULL_CHAN TTY_CHAN \
+	    BINFMT_MISC BLOCK BLK_DEV BLK_DEV_INITRD
+  else
+    # config kvm configs (for older arm/arm64 kernels)
+    kconfigs_y VIRTUALIZATION HYPERVISOR_GUEST PARAVIRT KVM_GUEST \
+      PCI PCI_MSI VIRTIO BLOCK BLK_DEV BLK_DEV_INITRD \
+      VIRTIO_PCI VIRTIO_BLK VIRTIO_CONSOLE VIRTIO_NET VIRTIO_INPUT \
+      NETWORK_FILESYSTEMS NET_9P NET_9P_VIRTIO 9P_FS 9P_FS_POSIX_ACL
+  fi
   if [ $ARCH = arm -o $ARCH = arm64 ]; then
     kconfigs_y ARM_AMBA SERIAL_AMBA_PL011 SERIAL_AMBA_PL011_CONSOLE
+  elif [ $ARCH = x86_64 -o $ARCH = i386 ]; then
+    kconfigs_y SERIAL_8250 SERIAL_8250_CONSOLE
   fi
   make olddefconfig O=$1
 }
@@ -192,6 +202,10 @@ build_kernel() { # workdir rebuild
     arm64)
     make Image.gz -j $JOBS O=$OUTDIR
     cp -f $OUTDIR/arch/arm64/boot/Image.gz $VMLINUZ
+    ;;
+    um)
+    make vmlinux -j $JOBS O=$OUTDIR
+    cp -f $OUTDIR/vmlinux $VMLINUZ
     ;;
   esac
   )
@@ -261,9 +275,17 @@ EOF
 
   cat > mincshell.sh << EOF
 #!/bin/sh
+mount_host() {
+  if grep -q hostfs /proc/filesystems ; then
+    mount -t hostfs -o / minc /mnt
+  else
+    mount -t 9p -o trans=virtio,version=9p2000.L,posixacl,cache=none minc /mnt
+  fi
+  return $?
+}
 
 run_minc() {
-if mount -t 9p -o trans=virtio minc /mnt -oversion=9p2000.L,posixacl,cache=none ; then
+if mount_host; then
   if [ -f /mnt/run.sh ]; then
     /bin/cttyhack sh /mnt/run.sh
     exec poweroff
@@ -449,7 +471,7 @@ case "$ARCH" in
     exit 1
   fi
   ;;
-  i386)
+  i386|um)
   export CROSS_COMPILE=
   GCC_URL=
   ;;

--- a/libexec/minc-exec
+++ b/libexec/minc-exec
@@ -71,7 +71,7 @@ if [ $$ -eq 1 ]; then
     echo "#!/bin/sh" > $MINC_TMPDIR/run.sh
     echo "stty rows `tput lines`; stty cols `tput cols`" >> $MINC_TMPDIR/run.sh
     echo "minc $MINC_GUEST_OPT \"$@\"" >> $MINC_TMPDIR/run.sh
-    minc_moult "$MINC_ARCH" "$MINC_TMPDIR" "ro quiet console=tty0"
+    minc_moult "$MINC_ARCH" "$MINC_TMPDIR" "ro quiet"
     exit $? # failsafe
   fi
 

--- a/libexec/minc-moult
+++ b/libexec/minc-moult
@@ -52,7 +52,7 @@ minc_moult() { # arch virtdir kernel_opt
   ERMINEDIR=$LIBEXEC/ermine
   prepare_arch $1
   [ $ARCH = "um" ] && exec $ERMINEDIR/vmlinuz.$ARCH mem=512M \
-	  initrd=$ERMINEDIR/initramfs.$ARCH hostfs=$2
+	  initrd=$ERMINEDIR/initramfs.$ARCH hostfs=$2 $3
   exec qemu-system-${QEMU_ARCH} $QEMU_OPT \
     -kernel $ERMINEDIR/vmlinuz.$ARCH -initrd $ERMINEDIR/initramfs.$ARCH \
     -nographic -append "$3" \

--- a/libexec/minc-moult
+++ b/libexec/minc-moult
@@ -36,7 +36,7 @@ prepare_arch() { # arch
     ;;
   um|uml)
     ARCH=um
-    UM_ARCH=$HOSTARCH
+    QEMU_TTY=tty0
     UM_OPT=""
     ;;
   *)
@@ -52,10 +52,10 @@ minc_moult() { # arch virtdir kernel_opt
   ERMINEDIR=$LIBEXEC/ermine
   prepare_arch $1
   [ $ARCH = "um" ] && exec $ERMINEDIR/vmlinuz.$ARCH mem=512M \
-	  initrd=$ERMINEDIR/initramfs.$ARCH hostfs=$2 con0=fd:0,fd:1 con1=null con=pts $3
+	  initrd=$ERMINEDIR/initramfs.$ARCH hostfs=$2 con0=fd:0,fd:1 con1=null con=pts $3 console=ttyS0
   exec qemu-system-${QEMU_ARCH} $QEMU_OPT \
     -kernel $ERMINEDIR/vmlinuz.$ARCH -initrd $ERMINEDIR/initramfs.$ARCH \
-    -nographic -append "$3" \
+    -nographic -append "$3 console=tty0" \
     -virtfs local,id=minc,path=$2,security_model=none,mount_tag=minc
 }
 

--- a/libexec/minc-moult
+++ b/libexec/minc-moult
@@ -52,7 +52,7 @@ minc_moult() { # arch virtdir kernel_opt
   ERMINEDIR=$LIBEXEC/ermine
   prepare_arch $1
   [ $ARCH = "um" ] && exec $ERMINEDIR/vmlinuz.$ARCH mem=512M \
-	  initrd=$ERMINEDIR/initramfs.$ARCH hostfs=$2 $3
+	  initrd=$ERMINEDIR/initramfs.$ARCH hostfs=$2 con0=fd:0,fd:1 con1=null con=pts $3
   exec qemu-system-${QEMU_ARCH} $QEMU_OPT \
     -kernel $ERMINEDIR/vmlinuz.$ARCH -initrd $ERMINEDIR/initramfs.$ARCH \
     -nographic -append "$3" \

--- a/libexec/minc-moult
+++ b/libexec/minc-moult
@@ -34,6 +34,11 @@ prepare_arch() { # arch
     QEMU_ARCH=aarch64
     QEMU_OPT="$QEMU_OPT -M virt -cpu cortex-a57"
     ;;
+  um|uml)
+    ARCH=um
+    UM_ARCH=$HOSTARCH
+    UM_OPT=""
+    ;;
   *)
     echo "Sorry, $ARCH is not supported yet."
     exit 1
@@ -46,6 +51,8 @@ prepare_arch() { # arch
 minc_moult() { # arch virtdir kernel_opt
   ERMINEDIR=$LIBEXEC/ermine
   prepare_arch $1
+  [ $ARCH = "um" ] && exec $ERMINEDIR/vmlinuz.$ARCH mem=512M \
+	  initrd=$ERMINEDIR/initramfs.$ARCH hostfs=$2
   exec qemu-system-${QEMU_ARCH} $QEMU_OPT \
     -kernel $ERMINEDIR/vmlinuz.$ARCH -initrd $ERMINEDIR/initramfs.$ARCH \
     -nographic -append "$3" \

--- a/minc
+++ b/minc
@@ -50,6 +50,7 @@ usage() { # [error messages]
   echo "    --arch ARCH		Alias of --cross"
   echo "    --nopriv DIR	Run MINC without root privilege on given <DIR>"
   echo "    --qemu		Run MINC in qemu-kvm instead of chroot"
+  echo "    --um		Run MINC in user-mode-linux instead of chroot"
   echo "    --debug		Debug mode"
   exit $#
 }
@@ -214,6 +215,10 @@ case "$cmd" in
     ;;
   --qemu)
     export MINC_QEMU=1
+    ;;
+  --um)
+    export MINC_QEMU=1
+    export MINC_ARCH=um
     ;;
   --help|-h) # Help Message
     usage


### PR DESCRIPTION
User-mode linux is now supported.
For ermine-breeder, it can build um kernel with --arch um. While minc side, minc --um boots um-based container.