### PR TITLE
mount overlayfs correctly on ubuntu 16.04

### DIFF
--- a/libexec/minc-coat
+++ b/libexec/minc-coat
@@ -33,7 +33,7 @@ if [ "$MINC_DIRECT" ]; then
   mount -o bind $BASEDIR $RD
 else
   :;: 'Mount overlayed root directory';:
-  if grep -v overlayfs /proc/filesystems | grep -q overlay ; then
+  if grep -wq overlay /proc/filesystems ; then
     mount -t overlay -o upperdir=$UD,lowerdir=$BASEDIR,workdir=$WD overlayfs $RD
   else
     :;: 'Workaround for ubuntu 14.10 (out-of-tree overlayfs)';:

--- a/libexec/minc-coat
+++ b/libexec/minc-coat
@@ -33,11 +33,11 @@ if [ "$MINC_DIRECT" ]; then
   mount -o bind $BASEDIR $RD
 else
   :;: 'Mount overlayed root directory';:
-  if grep -q overlayfs /proc/filesystems ; then
+  if grep -v overlayfs /proc/filesystems | grep -q overlay ; then
+    mount -t overlay -o upperdir=$UD,lowerdir=$BASEDIR,workdir=$WD overlayfs $RD
+  else
     :;: 'Workaround for ubuntu 14.10 (out-of-tree overlayfs)';:
     mount -t overlayfs -o upperdir=$UD,lowerdir=$BASEDIR overlayfs $RD
-  else
-    mount -t overlay -o upperdir=$UD,lowerdir=$BASEDIR,workdir=$WD overlayfs $RD
   fi
 fi
 elif [ $CMD = unbind ]; then


### PR DESCRIPTION
This part is workaround for ubuntu 14.10 or earlier when the module
name of overlayfs was "overlayfs". However, ubuntu 16.04 has the name
"overlayfs" as an alias for the module name. So, /proc/filesystems has
both "overlay" and "overlayfs", and the mount without "workdir" option
is executed and the mount fails.

This patch prevents the mount without workdir on Ubuntu 16.04, and
mounts it correctly.