### PR TITLE
Added option to squash Docker image layers and effectively apply the Dockerfile actions

### DIFF
--- a/marten
+++ b/marten
@@ -91,16 +91,35 @@ pull_docker() {
   echo "Pulled. Importing image: $NAME"
   LASTID=`cat $TMPDIR/manifest.json | jq -r .layers[].digest | tail -n 1`
   LASTID=${LASTID##*:}
-  cat $TMPDIR/manifest.json | jq -r .layers[].digest | while read d; do
+  if [ "$SQUASH" = "true" ] ; then
     tmproot=`mktemp -d $TMPDIR/layer-root-XXXXXX`
-    ID=${d##*:}
-    tar --force-local -xf $TMPDIR/$d -C $tmproot
-    export MINC_IMPORT_UUID=$ID
-    test "$ID" = "$LASTID" && export MINC_IMPORT_NAME=${NAME##*/}
+    cat $TMPDIR/manifest.json | jq -r .layers[].digest | while read d; do
+      ID=${d##*:}
+      tar --force-local -xf $TMPDIR/$d -C $tmproot
+      cd $tmproot
+      for whiteout in `find . -name '*.wh.*'` ; do
+        deletedFile=`echo $whiteout | sed -e "s|\.wh\.||"`
+        rm -rf $whiteout
+        rm -rf $deletedFile
+      done
+      cd ../..
+      export MINC_IMPORT_UUID=$ID
+    done
+    export MINC_IMPORT_NAME=${NAME##*/}
     $MINCFARM import $tmproot
-    export MINC_BASE_UUID=$ID
-    rm -rf $tmproot
-  done
+  else
+    cat $TMPDIR/manifest.json | jq -r .layers[].digest | while read d; do
+      tmproot=`mktemp -d $TMPDIR/layer-root-XXXXXX`
+      ID=${d##*:}
+      tar --force-local -xf $TMPDIR/$d -C $tmproot
+      export MINC_IMPORT_UUID=$ID
+      test "$ID" = "$LASTID" && export MINC_IMPORT_NAME=${NAME##*/}
+      $MINCFARM import $tmproot
+      export MINC_BASE_UUID=$ID
+      rm -rf $tmproot
+    done
+  fi
+
   rm -rf $TMPDIR
   exit 0
 }
@@ -120,6 +139,7 @@ case $cmd in
   do_list $cmd $*
   ;;
   pull)
+  if [ "$1" = "--squash" ] ; then SQUASH=true ; shift ; else SQUASH=false ; fi
   pull_docker $1
   ;;
   import)


### PR DESCRIPTION
The ``--squash`` option honors the Dockerfile changes that have been applied in each layer, e.g. rename, move, etc. The benefit of using _squashed_ Docker images:

* The resulting container's file/folder structure is the same as in a corresponding Docker container.
*  We preserve space (there is only only one layer to deal with) when we instantiate the container.

Example:

```
# Download the most recent Ubuntu image and generate corresponding MINCS/Marten
# image that contains just one layer where all original Dockerfile actions have
# been applied. This is achieved by using the '--squash' option.

marten pull --squash ubuntu
```

The feature has been described in issue #20 but I'm providing the same information here, just for clarity.

---

The most recent [Docker image specification](https://github.com/moby/moby/blob/master/image/spec/v1.2.md#creating-an-image-filesystem-changeset) describes what metadata is used in the layers in order to detect changes that have occurred in the layered structure (e.g. deleted files/folders).

Currently MINCS has the functionality to import Docker image layers but the container instantiation is implemented with simple "merging" of all layers which doesn't honor the changes that have been described in the original Dockerfile. This means that if ``layer 1`` provides certain file and ``layer 2`` deletes this file, MINCS won't pick this change and the instantiated container will provide the file while in reality this file should not be there.

Recently I developed a _squash_ extension for ``marten pull`` which generates only one layer and honors all changes that have occurred in the original Docker layers.

https://github.com/ivandavidov/mincs/blob/extract-docker-layers/marten#L94

My recent tests indicate that the original ``marten pull`` functionality is not affected and the _squash_ functionality works as expected. I have tested the _squash_ functionality with the most recent [Ubuntu image](https://hub.docker.com/_/ubuntu/).

Note that in the [Ubuntu's Dockerfile](https://github.com/tianon/docker-brew-ubuntu-core/blob/c7e9f7353aa24d1c35f501e06382aed1b540e85f/bionic/Dockerfile#L36) the content of the directory ``/var/lib/apt/lists`` is removed. When we use ``marten pull`` the folder contains both the original set of files and all special metadata files starting with ``.wh.``. When we use ``marten pull --squash`` the directory is empty, just as expected.

I'll test the _squash_ functionality a little more and if you don't mind, later I'll propose it for inclusion in your project as pull request.

Here is how the _squash_ functionality currently works.

```
root@ivan:/home/ivan/p/g/ivandavidov/mincs# ./marten pull --squash ubuntu
Trying to pull library/ubuntu:latest
Downloading manifest.json
Downloading config.json
######################################################################## 100,0%
Downloading sha256:473ede7ed136b710ab2dd51579af038b7d00fbbf6a1790c6294c93666203c0a6
######################################################################## 100,0%
Downloading sha256:c46b5fa4d940569e49988515c1ea0295f56d0a16228d8f854e27613f467ec892
######################################################################## 100,0%
Downloading sha256:93ae3df89c92cb1d20e9c09f499e693d3a8a8cef161f7158f7a9a3b5d06e4ef2
######################################################################## 100,0%
Downloading sha256:6b1eed27cadec5de8051d56697b0b67527e4076deedceefb41b7b2ea9b900459
######################################################################## 100,0%
Pulled. Importing image: library/ubuntu
7fc8fab1a721d4179f4aefd81e1674f54b468085d0be7eac8beb11371cbff911
root@ivan:/home/ivan/p/g/ivandavidov/mincs# 
root@ivan:/home/ivan/p/g/ivandavidov/mincs# ./marten li
ID		SIZE	NAME
7fc8fab1a721	76M	ubuntu
root@ivan:/home/ivan/p/g/ivandavidov/mincs# 
root@ivan:/home/ivan/p/g/ivandavidov/mincs# ./minc -r ubuntu /bin/bash
3c623193a055a3ca4a1f689a00580084309810c41d04443c369e5610b2ec238c
root@ivan:/# 
root@ivan:/# ls
bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
root@ivan:/# 
root@ivan:/# exit
exit
To reuse this, run: ./minc -t 3c623193a055
root@ivan:/home/ivan/p/g/ivandavidov/mincs#
```